### PR TITLE
GLES 3.10 / Raspberry Pi Support

### DIFF
--- a/src/widget/glow_canvas.rs
+++ b/src/widget/glow_canvas.rs
@@ -353,8 +353,8 @@ unsafe fn init_gl_resources(gl: &eframe::glow::Context) -> OpenGLResources {
         let vert = gl.create_shader(glow::VERTEX_SHADER).expect("create vert");
         debug_assert_eq!(gl.get_error(), 0);
         let source = "
-#version 330
-
+#version 310 es
+precision mediump float; 
 uniform vec2 u_screen_size;
 in      vec2 a_pos;
 in      vec2 a_tc;
@@ -384,7 +384,8 @@ void main() {
             .create_shader(glow::FRAGMENT_SHADER)
             .expect("crate fragment");
         let source = "
-#version 330
+#version 310 es
+precision mediump float; 
 
 uniform sampler2D u_sampler;
 


### PR DESCRIPTION
Hi,

Thank you for Annelid!

I'm presenting this PR just to show the changes I've made to get Annelid running on a Raspberry Pi, as GLSL 3.30 is not supported on the Pi.  I'm seeking guidance as to how you would see the changes being integrated, perhaps by way of a features flag, or by querying GL_SHADING_LANGUAGE_VERSION and tailoring the shader appropriately?

Thanks again.  Tom [tombardier]